### PR TITLE
replace argparse with clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,10 +16,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "argparse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -60,10 +80,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "cntr"
 version = "1.4.1"
 dependencies = [
  "argparse",
+ "clap",
  "cntr-fuse",
  "concurrent-hashmap",
  "cpuprofiler",
@@ -135,6 +171,15 @@ name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "instant"
@@ -266,6 +311,33 @@ name = "spin"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 [dependencies]
 cpuprofiler = { version = "0.0.*", optional = true }
 argparse = "0.2.*"
+clap = "2"
 log = "0.4.*"
 libc = "0.2.*"
 parking_lot = "0.11.*"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -5,6 +5,7 @@ extern crate nix;
 use clap::{crate_authors, crate_version, values_t, App, AppSettings, Arg, ArgMatches, SubCommand};
 use cntr::pwnam;
 use cntr::ContainerType;
+use std::path::Path;
 use std::{env, process};
 
 fn command_arg(index: u64) -> Arg<'static, 'static> {
@@ -91,6 +92,8 @@ fn exec(args: &ArgMatches, setcap: bool) {
 fn main() {
     let attach_command = SubCommand::with_name("attach")
         .about("Enter container")
+        .version(crate_version!())
+        .author(crate_authors!("\n"))
         .setting(AppSettings::DisableVersion)
         .arg(
             Arg::with_name("effective-user")
@@ -121,22 +124,37 @@ fn main() {
 
     let exec_command = SubCommand::with_name("exec")
         .about("Execute command in container filesystem")
+        .version(crate_version!())
+        .author(crate_authors!("\n"))
         .arg(command_arg(1));
 
-    let matches = App::new("Cntr")
+    let main_app = App::new("Cntr")
         .about("Enter or executed in container")
         .version(crate_version!())
         .author(crate_authors!("\n"))
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .setting(AppSettings::VersionlessSubcommands)
         .subcommand(attach_command)
-        .subcommand(exec_command)
-        .get_matches();
+        .subcommand(exec_command.clone());
 
-    match matches.subcommand() {
-        ("exec", Some(exec_matches)) => exec(exec_matches, true),
-        ("attach", Some(attach_matches)) => attach(attach_matches),
-        ("", None) => unreachable!(), // beause of AppSettings::SubCommandRequired
-        _ => unreachable!(),
-    };
+    // find and run subcommand/app
+    match std::env::current_exe() {
+        Ok(exe) => {
+            if exe == Path::new(cntr::SETCAP_EXE) {
+                let matches = exec_command.get_matches();
+                exec(&matches, true);
+            } else {
+                let matches = main_app.get_matches();
+                match matches.subcommand() {
+                    ("exec", Some(exec_matches)) => exec(exec_matches, true),
+                    ("attach", Some(attach_matches)) => attach(attach_matches),
+                    ("", None) => unreachable!(), // beause of AppSettings::SubCommandRequired
+                    _ => unreachable!(),
+                };
+            }
+        }
+        Err(e) => {
+            eprintln!("failed to resolve executable: {}", e);
+            process::exit(1);
+        }
+    }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -2,7 +2,7 @@ extern crate argparse;
 extern crate cntr;
 extern crate nix;
 
-use clap::{crate_version, crate_authors, value_t, App, AppSettings, Arg, ArgMatches, SubCommand};
+use clap::{crate_version, crate_authors, values_t, App, AppSettings, Arg, ArgMatches, SubCommand};
 use cntr::pwnam;
 use cntr::ContainerType;
 use std::{env, process};
@@ -18,8 +18,8 @@ fn attach(args: &ArgMatches) {
 
     let mut container_types = vec![];
     if args.is_present("type") {
-        let v = value_t!(args.value_of("type"), ContainerType).unwrap_or_else(|e| e.exit());
-        container_types = vec![cntr::lookup_container_type(&v)];
+        let types = values_t!(args.values_of("type"), ContainerType).unwrap_or_else(|e| e.exit());
+        container_types = types.into_iter().map(|t| cntr::lookup_container_type(&t)).collect();
     }
 
     let mut options = cntr::AttachOptions {
@@ -96,8 +96,9 @@ fn main() {
                 .long("type")
                 .takes_value(true)
                 .empty_values(false)
+                .require_delimiter(true)
                 .value_name("TYPE")
-                .help("Container type")
+                .help("Container types to try (sperated by ',') [default: all but command]")
                 .possible_values(&ContainerType::variants()),
         )
         .arg(

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -13,22 +13,28 @@ mod podman;
 mod process_id;
 mod rkt;
 
+use clap::arg_enum;
+
 pub trait Container: Debug {
     fn lookup(&self, id: &str) -> Result<Pid>;
     fn check_required_tools(&self) -> Result<()>;
 }
 
-pub const AVAILABLE_CONTAINER_TYPES: &[&str] = &[
-    "process_id",
-    "rkt",
-    "podman",
-    "docker",
-    "nspawn",
-    "lxc",
-    "lxd",
-    "command",
-    "containerd",
-];
+arg_enum! {
+    #[derive(Debug)]
+    #[allow(non_camel_case_types)]
+    pub enum ContainerType {
+        process_id,
+        rkt,
+        podman,
+        docker,
+        nspawn,
+        lxc,
+        lxd,
+        command,
+        containerd,
+    }
+}
 
 fn default_order() -> Vec<Box<dyn Container>> {
     let containers: Vec<Box<dyn Container>> = vec![
@@ -47,19 +53,18 @@ fn default_order() -> Vec<Box<dyn Container>> {
         .collect()
 }
 
-pub fn lookup_container_type(name: &str) -> Option<Box<dyn Container>> {
-    Some(match name {
-        "process_id" => Box::new(process_id::ProcessId {}),
-        "rkt" => Box::new(rkt::Rkt {}),
-        "podman" => Box::new(podman::Podman {}),
-        "docker" => Box::new(docker::Docker {}),
-        "nspawn" => Box::new(nspawn::Nspawn {}),
-        "lxc" => Box::new(lxc::Lxc {}),
-        "lxd" => Box::new(lxd::Lxd {}),
-        "containerd" => Box::new(containerd::Containerd {}),
-        "command" => Box::new(command::Command {}),
-        _ => return None,
-    })
+pub fn lookup_container_type(name: &ContainerType) -> Box<dyn Container> {
+    match name {
+        ContainerType::process_id => Box::new(process_id::ProcessId {}),
+        ContainerType::rkt => Box::new(rkt::Rkt {}),
+        ContainerType::podman => Box::new(podman::Podman {}),
+        ContainerType::docker => Box::new(docker::Docker {}),
+        ContainerType::nspawn => Box::new(nspawn::Nspawn {}),
+        ContainerType::lxc => Box::new(lxc::Lxc {}),
+        ContainerType::lxd => Box::new(lxd::Lxd {}),
+        ContainerType::containerd => Box::new(containerd::Containerd {}),
+        ContainerType::command => Box::new(command::Command {}),
+    }
 }
 
 pub fn lookup_container_pid(

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -31,8 +31,8 @@ arg_enum! {
         nspawn,
         lxc,
         lxd,
-        command,
         containerd,
+        command,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub use container::{lookup_container_type, AVAILABLE_CONTAINER_TYPES};
+pub use container::{lookup_container_type, ContainerType};
 pub use logging::enable_debug_log;
 pub use user_namespace::DEFAULT_ID_MAP;
 


### PR DESCRIPTION
Clap: a modern argpaser which does the thinking for you. 

The CLI stays the same except: 
- you can now specify ordered lists of container types `ctnr --type docker,rkt`
- passing arguments to a command requires `--` if command arguments contain `-`-flags. Example: `cntr attach --type docker -- ls -l /dev`

Example:
```
> cargo run -- attach -h
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/cntr attach -h`
cntr-attach
Enter container

USAGE:
    cntr attach [OPTIONS] <id> [command]...

FLAGS:
    -h, --help    Prints help information

OPTIONS:
        --effective-user <EFFECTIVE_USER>    effective username that should be owner of new created files on the host
    -t, --type <TYPE>                        Container types to try (sperated by ','). [default: all but command]
                                             [possible values: process_id, rkt, podman, docker, nspawn, lxc, lxd,
                                             containerd, command]

ARGS:
    <id>            container id, container name or process id
    <command>...    Command and its arguments to execute after attach. Consider prepending it with '-- ' to prevent
                    parsing of '-x'-like flags. [default: $SHELL]
```