### PR TITLE
fix permissions of temporary directories

### DIFF
--- a/src/dotcntr.rs
+++ b/src/dotcntr.rs
@@ -5,6 +5,10 @@ use nix::unistd::Pid;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::os::unix::prelude::*;
+use std::{
+    fs::{set_permissions, Permissions},
+    os::unix::fs::PermissionsExt,
+};
 
 use crate::capabilities;
 use crate::procfs::ProcStatus;
@@ -50,6 +54,12 @@ impl DotcntrDir {
 
 pub fn create(process_status: &ProcStatus) -> Result<DotcntrDir> {
     let dotcntr_dir = tryfmt!(tmp::tempdir(), "failed to create temporary directory");
+    let permissions = Permissions::from_mode(0o755);
+    tryfmt!(
+        set_permissions(dotcntr_dir.path(), permissions),
+        "cannot change permissions of '{}'",
+        dotcntr_dir.path().display()
+    );
     let dotcntr_fd = tryfmt!(
         fcntl::open(
             dotcntr_dir.path(),


### PR DESCRIPTION
Having them non-readable by non-root users broke for example
breakpointHook in nixpkgs.
This bug was introduced in 4aa6c94b9678fc45f6ee4606dea4365dd77c92da