### PR TITLE
Fix build on 32-bit platforms

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645937171,
-        "narHash": "sha256-n9f9GZBNMe8UMhcgmmaXNObkH01jjgp7INMrUgBgcy4=",
+        "lastModified": 1655034456,
+        "narHash": "sha256-HXXyvGqZLa+2u8IPIRm/uNQiw+gBtTNu58YaXMJtKRc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "22dc22f8cedc58fcb11afe1acb08e9999e78be9c",
+        "rev": "72b1ec0a79b1fc50f6cc0694c2f0b1eb384a932e",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,11 +30,11 @@
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
     in {
-      integration-tests = import ./vm-test.nix {
+      inherit (import ./vm-test.nix {
         makeTest = import (nixpkgs + "/nixos/tests/make-test-python.nix");
         inherit pkgs;
         inherit (self.packages.${system}) cntr;
-      };
+      }) docker podman;
     };
   };
 }

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -1,4 +1,4 @@
-use libc::{self, c_int};
+use libc::{self, c_int, c_ulong};
 use nix::errno::Errno;
 use simple_error::try_with;
 use std::fs::File;
@@ -106,7 +106,7 @@ pub fn set_chroot_capability(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn last_capability() -> Result<u64> {
+fn last_capability() -> Result<c_ulong> {
     let path = "/proc/sys/kernel/cap_last_cap";
     let mut f = try_with!(File::open(path), "failed to open {}", path);
 
@@ -114,13 +114,13 @@ fn last_capability() -> Result<u64> {
     try_with!(f.read_to_string(&mut contents), "failed to read {}", path);
     contents.pop(); // remove newline
     Ok(try_with!(
-        contents.parse::<u64>(),
+        contents.parse::<c_ulong>(),
         "failed to parse capability, got: '{}'",
         contents
     ))
 }
 
-pub fn drop(inheritable_capabilities: u64) -> Result<()> {
+pub fn drop(inheritable_capabilities: c_ulong) -> Result<()> {
     // we need chroot at the moment for `exec` command
     let inheritable = inheritable_capabilities | 1 << CAP_SYS_CHROOT | 1 << CAP_SYS_PTRACE;
     let last_capability = try_with!(last_capability(), "failed to read capability limit");

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -933,7 +933,10 @@ impl Filesystem for CntrFs {
 
         let mut v = vec![0; size as usize];
         let buf = v.as_mut_slice();
-        tryfuse!(pread(get_filehandle(fh).fd.raw(), buf, offset as off_t), reply);
+        tryfuse!(
+            pread(get_filehandle(fh).fd.raw(), buf, offset as off_t),
+            reply
+        );
 
         reply.data(buf);
     }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -4,7 +4,7 @@ use cntr_fuse::{
     Request,
 };
 use concurrent_hashmap::ConcHashMap;
-use libc::{self, c_long, dev_t};
+use libc::{self, c_long, c_ulong, dev_t, off_t};
 use log::debug;
 use nix::errno::Errno;
 use nix::fcntl::{self, AtFlags, OFlag};
@@ -346,7 +346,7 @@ impl CntrFs {
         }
 
         if let Some(s) = size {
-            unistd::ftruncate(fd.raw(), s as i64)?;
+            unistd::ftruncate(fd.raw(), s as off_t)?;
         }
         if mtime != cntr_fuse::UtimeSpec::Omit || atime != cntr_fuse::UtimeSpec::Omit {
             let inode = self.inode(ino)?;
@@ -361,8 +361,8 @@ impl CntrFs {
         let dirp = unsafe { &mut (*(fh as *mut DirP)) };
         assert!(dirp.magic == DIRP_MAGIC);
 
-        if (offset as i64) != dirp.offset {
-            dirent::seekdir(&mut dirp.dp, offset as i64);
+        if (offset as c_long) != dirp.offset {
+            dirent::seekdir(&mut dirp.dp, offset as c_long);
             dirp.entry = None;
             dirp.offset = 0;
         }
@@ -380,7 +380,7 @@ impl CntrFs {
                     match reply {
                         ReplyDirectory::Directory(ref mut r) => r.add(
                             entry.d_ino,
-                            dirp.offset,
+                            dirp.offset as i64,
                             dtype_kind(entry.d_type),
                             OsStr::from_bytes(name.to_bytes()),
                         ),
@@ -388,7 +388,7 @@ impl CntrFs {
                             match self.lookup_inode(ino, OsStr::from_bytes(name.to_bytes())) {
                                 Ok((attr, generation)) => r.add(
                                     entry.d_ino,
-                                    dirp.offset,
+                                    dirp.offset as i64,
                                     OsStr::from_bytes(name.to_bytes()),
                                     &TTL,
                                     &attr,
@@ -416,7 +416,7 @@ impl CntrFs {
     fn attr_from_stat(&self, attr: stat::FileStat) -> FileAttr {
         let ctime = UNIX_EPOCH + Duration::new(attr.st_ctime as u64, attr.st_ctime_nsec as u32);
         FileAttr {
-            ino: attr.st_ino, // replaced by ino pointer
+            ino: attr.st_ino as u64, // replaced by ino pointer
             size: attr.st_size as u64,
             blocks: attr.st_blocks as u64,
             atime: UNIX_EPOCH + Duration::new(attr.st_atime as u64, attr.st_atime_nsec as u32),
@@ -933,7 +933,7 @@ impl Filesystem for CntrFs {
 
         let mut v = vec![0; size as usize];
         let buf = v.as_mut_slice();
-        tryfuse!(pread(get_filehandle(fh).fd.raw(), buf, offset), reply);
+        tryfuse!(pread(get_filehandle(fh).fd.raw(), buf, offset as off_t), reply);
 
         reply.data(buf);
     }
@@ -951,7 +951,7 @@ impl Filesystem for CntrFs {
         fsuid::set_root();
         let dst_fd = get_filehandle(fh).fd.raw();
 
-        let written = tryfuse!(pwrite(dst_fd, data, offset), reply);
+        let written = tryfuse!(pwrite(dst_fd, data, offset as off_t), reply);
 
         reply.written(written as u32);
     }
@@ -1288,7 +1288,7 @@ impl Filesystem for CntrFs {
         let handle = get_filehandle(fh);
         let flags = fcntl::FallocateFlags::from_bits_truncate(mode as i32);
         tryfuse!(
-            fcntl::fallocate(handle.fd.raw(), flags, offset as i64, length as i64),
+            fcntl::fallocate(handle.fd.raw(), flags, offset as off_t, length as off_t),
             reply
         );
         reply.ok();
@@ -1315,7 +1315,7 @@ impl Filesystem for CntrFs {
             get_filehandle(fh).fd.raw()
         };
 
-        let cmd = u64::from(_cmd);
+        let cmd = c_ulong::from(_cmd);
 
         if out_size > 0 {
             let mut out = vec![0; out_size as usize];

--- a/src/procfs/mod.rs
+++ b/src/procfs/mod.rs
@@ -1,4 +1,4 @@
-use libc::{pid_t, c_ulong};
+use libc::{c_ulong, pid_t};
 use nix::unistd::Pid;
 use simple_error::{try_with, SimpleError};
 use std::env;

--- a/src/procfs/mod.rs
+++ b/src/procfs/mod.rs
@@ -1,4 +1,4 @@
-use libc::pid_t;
+use libc::{pid_t, c_ulong};
 use nix::unistd::Pid;
 use simple_error::{try_with, SimpleError};
 use std::env;
@@ -19,8 +19,8 @@ pub fn get_path() -> PathBuf {
 pub struct ProcStatus {
     pub global_pid: Pid,
     pub local_pid: Pid,
-    pub inherited_capabilities: u64,
-    pub effective_capabilities: u64,
+    pub inherited_capabilities: c_ulong,
+    pub effective_capabilities: c_ulong,
 }
 
 pub fn status(target_pid: Pid) -> Result<ProcStatus> {
@@ -28,8 +28,8 @@ pub fn status(target_pid: Pid) -> Result<ProcStatus> {
     let file = try_with!(File::open(&path), "failed to open {}", path.display());
 
     let mut ns_pid: Option<Pid> = None;
-    let mut inherited_caps: Option<u64> = None;
-    let mut effective_caps: Option<u64> = None;
+    let mut inherited_caps: Option<c_ulong> = None;
+    let mut effective_caps: Option<c_ulong> = None;
 
     let reader = BufReader::new(file);
     for line in reader.lines() {
@@ -48,7 +48,7 @@ pub fn status(target_pid: Pid) -> Result<ProcStatus> {
         } else if columns[0] == "CapInh:" {
             if let Some(cap_string) = columns.last() {
                 let cap = try_with!(
-                    u64::from_str_radix(cap_string, 16),
+                    c_ulong::from_str_radix(cap_string, 16),
                     "read invalid capability from proc: '{}'",
                     columns[1]
                 );
@@ -57,7 +57,7 @@ pub fn status(target_pid: Pid) -> Result<ProcStatus> {
         } else if columns[0] == "CapEff:" {
             if let Some(cap_string) = columns.last() {
                 let cap = try_with!(
-                    u64::from_str_radix(cap_string, 16),
+                    c_ulong::from_str_radix(cap_string, 16),
                     "read invalid capability from proc: '{}'",
                     columns[1]
                 );

--- a/vm-test.nix
+++ b/vm-test.nix
@@ -6,6 +6,7 @@
 makeTest {
   name = "docker";
   nodes.server = { ... }: {
+    virtualisation.oci-containers.backend = "docker";
     virtualisation.oci-containers.containers.nginx = {
       image = "nginx-container";
       imageFile = pkgs.dockerTools.examples.nginx;


### PR DESCRIPTION
Makes cntr build on 32-bit platforms. nix doesn't support 64-bit file offsets on 32-bit platforms, so this involves some truncating casts that will cause things to misbehave with large files.

I have built this for armv7l, i686 and x86_64 and tested it on armv7l.