### PR TITLE
Create `/.cntr/pid` file with `0644` permissions

### DIFF
--- a/src/dotcntr.rs
+++ b/src/dotcntr.rs
@@ -31,7 +31,7 @@ impl DotcntrDir {
         let mut file = try_with!(
             OpenOptions::new()
                 .create_new(true)
-                .mode(0o600)
+                .mode(0o644)
                 .write(true)
                 .open(&path),
             "failed to create {}",


### PR DESCRIPTION
With the default `0600` permissions, `cntr exec` inside nix sandbox fails with the following error:

```
[nixbld@localhost:/var/lib/cntr/build/hello-2.12.1]$ cntr exec "$SHELL"
failed to open /.cntr/pid, Permission denied (os error 13)
```