### PR TITLE
attach: expose container timezone to attached shell

### DIFF
--- a/src/attach/child.rs
+++ b/src/attach/child.rs
@@ -1,5 +1,5 @@
 use log::{debug, warn};
-use rustix::fs::{AtFlags, CWD, Dir, FileType, statat};
+use rustix::fs::{AtFlags, CWD, Dir, FileType, Mode, OFlags, ResolveFlags, openat2, statat};
 use rustix::io::Errno;
 use rustix::mount::{
     MountFlags, MountPropagationFlags, MoveMountFlags, OpenTreeFlags, mount, mount_change,
@@ -135,6 +135,51 @@ fn apply_idmapped_mounts(userns_fd: BorrowedFd, base_dir: &Path) -> Result<(), A
     Ok(())
 }
 
+/// Copy the container's /etc/localtime (resolved inside the container root, so
+/// symlinks cannot escape) to the tmpfs and bind-mount it over the host's
+/// /etc/localtime, so the attached shell sees the container's timezone.
+fn setup_container_timezone(container_root_fd: BorrowedFd, base_dir: &Path) -> Option<PathBuf> {
+    let localtime_fd = match openat2(
+        container_root_fd,
+        "etc/localtime",
+        OFlags::RDONLY | OFlags::CLOEXEC,
+        Mode::empty(),
+        ResolveFlags::IN_ROOT,
+    ) {
+        Ok(fd) => fd,
+        Err(e) => {
+            debug!("container has no readable /etc/localtime: {}", e);
+            return None;
+        }
+    };
+
+    let mut contents = Vec::new();
+    if let Err(e) =
+        std::io::Read::read_to_end(&mut std::fs::File::from(localtime_fd), &mut contents)
+    {
+        warn!("failed to read container /etc/localtime: {}", e);
+        return None;
+    }
+
+    let copy_path = base_dir.join(".localtime");
+    if let Err(e) = std::fs::write(&copy_path, &contents) {
+        warn!("failed to write {}: {}", copy_path.display(), e);
+        return None;
+    }
+
+    if let Err(e) = mount(
+        copy_path.as_path(),
+        "/etc/localtime",
+        "",
+        MountFlags::BIND,
+        None::<&std::ffi::CStr>,
+    ) {
+        debug!("failed to bind-mount container localtime: {}", e);
+    }
+
+    Some(copy_path)
+}
+
 /// Capture and attach container filesystem trees
 ///
 /// This function:
@@ -258,7 +303,7 @@ pub(crate) fn run(options: &mut ChildOptions) -> Result<std::convert::Infallible
     cgroup::move_to(getpid(), options.process_status.global_pid)?;
 
     // Step 3: Prepare command to execute
-    let cmd = Cmd::new(
+    let mut cmd = Cmd::new(
         options.command.clone(),
         options.arguments.clone(),
         options.process_status.global_pid,
@@ -350,6 +395,8 @@ pub(crate) fn run(options: &mut ChildOptions) -> Result<std::convert::Infallible
         source,
     })?;
 
+    let localtime_copy = setup_container_timezone(container_root_fd.as_fd(), &base_dir);
+
     // Capture container filesystem and attach to base_dir
     capture_and_attach_container_trees(
         container_root_fd,
@@ -357,6 +404,11 @@ pub(crate) fn run(options: &mut ChildOptions) -> Result<std::convert::Infallible
         our_mount_ns,
         &base_dir,
     )?;
+
+    // TZ fallback for hosts where the /etc/localtime bind-mount was not possible
+    if let Some(path) = localtime_copy {
+        cmd.env_default("TZ", format!(":{}", path.display()));
+    }
 
     // Step 6: Enter other container namespaces and apply security context
     let in_user_ns = other_namespaces.iter().any(|ns| {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -127,6 +127,13 @@ impl Cmd {
         })
     }
 
+    /// Set an environment variable unless the container already defines it
+    pub(crate) fn env_default<K: Into<OsString>, V: Into<OsString>>(&mut self, key: K, value: V) {
+        self.environment
+            .entry(key.into())
+            .or_insert_with(|| value.into());
+    }
+
     /// Execute in attach mode - no chroot, uses overlay
     ///
     /// For attach, we stay in the overlay environment which provides access

--- a/vm-test.nix
+++ b/vm-test.nix
@@ -10,7 +10,14 @@ let
   busyboxImage = pkgs.dockerTools.buildLayeredImage {
     name = "busybox-test";
     tag = "latest";
-    contents = [ pkgs.busybox ];
+    contents = [
+      pkgs.busybox
+      # timezone differing from the host (UTC) to test issue #106
+      (pkgs.runCommand "container-localtime" { } ''
+        mkdir -p $out/etc
+        ln -s ${pkgs.tzdata}/share/zoneinfo/Europe/Berlin $out/etc/localtime
+      '')
+    ];
     config.Cmd = [
       "${pkgs.busybox}/bin/sleep"
       "infinity"
@@ -42,6 +49,10 @@ in
       server.wait_until_succeeds("docker inspect --format '{{.State.Running}}' busybox | grep true")
       server.succeed("cntr attach busybox true")
       server.succeed("cntr exec busybox -- /bin/sh -c 'echo exec test passed'")
+      # cntr must show the container's timezone, not the host's (issue #106)
+      server.succeed("date +%Z | grep -q UTC")
+      server.succeed("cntr attach busybox -- date +%Z | grep -qE 'CET|CEST'")
+      server.succeed("cntr exec busybox -- date +%Z | grep -qE 'CET|CEST'")
     '';
   };
   podman = testers.nixosTest {


### PR DESCRIPTION

The attach shell keeps the host filesystem at /, so /etc/localtime and
thus date reflected the host's timezone instead of the container's.
Copy the container's localtime to the cntr tmpfs, bind-mount it over
/etc/localtime in the private mount namespace and set TZ as a fallback.

Extend the docker NixOS test to verify the container timezone is used.

Fixes #106
