### PR TITLE
attach, exec: skip PTY when stdio is not a terminal

### DIFF
--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/nd5nx9gb3744mc8754r1wiqc9bpbganq-vm-test-run-docker

--- a/src/attach/child.rs
+++ b/src/attach/child.rs
@@ -420,17 +420,29 @@ pub(crate) fn run(options: &mut ChildOptions) -> Result<std::convert::Infallible
         ns.apply()?;
     }
 
-    // Step 7: Setup PTY (before applying AppArmor profile)
-    let pty_master = pty::open_ptm()?;
-    pty::attach_pts(&pty_master)?;
+    // Step 7: Setup PTY (before applying AppArmor profile), unless stdio is
+    // redirected: then we keep the inherited stdio so binary output is not
+    // mangled by a terminal (issue #181)
+    let pty_master = if pty::stdio_is_tty() {
+        let pty_master = pty::open_ptm()?;
+        pty::attach_pts(&pty_master)?;
+        Some(pty_master)
+    } else {
+        None
+    };
 
     // Step 8: Apply security context (UID/GID, capabilities) - NOT AppArmor yet
     crate::container_setup::apply_security_context(&mut options.process_status, in_user_ns)?;
 
-    // Step 9: Send ready signal + PTY fd to parent
+    // Step 9: Send ready signal (+ PTY fd if allocated) to parent
     let ready_msg = b"R";
-    let pty_fd = pty_master.as_fd();
-    options.socket.send(&[ready_msg], &[&pty_fd])?;
+    match &pty_master {
+        Some(pty_master) => {
+            let pty_fd = pty_master.as_fd();
+            options.socket.send(&[ready_msg], &[&pty_fd])?;
+        }
+        None => options.socket.send::<BorrowedFd>(&[ready_msg], &[])?,
+    }
 
     // Step 10: Change to base_dir
     if let Err(e) = env::set_current_dir(&base_dir) {

--- a/src/attach/mod.rs
+++ b/src/attach/mod.rs
@@ -42,8 +42,6 @@ pub(crate) enum AttachError {
     Fork(#[source] Errno),
     #[error("child did not send ready signal")]
     ChildNotReady,
-    #[error("expected PTY fd from child, got none")]
-    MissingPtyFd,
     #[error(transparent)]
     Pty(#[from] PtyError),
     #[error("failed to change cgroup")]

--- a/src/attach/parent.rs
+++ b/src/attach/parent.rs
@@ -25,13 +25,12 @@ pub(crate) fn run(
         return Err(AttachError::ChildNotReady);
     }
 
-    // Step 2: Receive PTY fd from child
+    // Step 2: Forward PTY I/O (if the child allocated one) and wait for the
+    // child to exit, propagating its exit status
     if fds.is_empty() {
-        return Err(AttachError::MissingPtyFd);
+        Ok(pty::wait_for_child(child_pid)?)
+    } else {
+        let pty_fd = fds.remove(0);
+        Ok(pty::forward_pty_and_wait(&pty_fd, child_pid)?)
     }
-    let pty_fd = fds.remove(0);
-
-    // Step 3: Forward PTY I/O and wait for child to exit
-    // This will block until child exits, then propagate the exit status
-    Ok(pty::forward_pty_and_wait(&pty_fd, child_pid)?)
 }

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -62,22 +62,27 @@ pub(crate) fn exec(opts: &ExecOptions) -> Result<std::convert::Infallible, ExecE
         source,
     })?;
 
-    // Create PTY for interactive command execution
-    let pty_master = pty::open_ptm()?;
+    // Create PTY for interactive command execution; skip it when stdio is
+    // redirected so binary output is not mangled by a terminal (issue #181)
+    let pty_master = if pty::stdio_is_tty() {
+        Some(pty::open_ptm()?)
+    } else {
+        None
+    };
 
     // Fork: child enters container and execs, parent forwards PTY I/O
     match fork().map_err(ExecError::Fork)? {
-        Fork::ParentOf(child) => {
-            // Parent: Forward PTY I/O and wait for child
-            Ok(pty::forward_pty_and_wait(&pty_master, child)?)
-        }
+        Fork::ParentOf(child) => match &pty_master {
+            Some(pty_master) => Ok(pty::forward_pty_and_wait(pty_master, child)?),
+            None => Ok(pty::wait_for_child(child)?),
+        },
         Fork::Child => {
             // Child: Setup PTY slave, enter container, exec command
             let Err(e) = exec_child(
                 &mut process_status,
                 opts.command.clone(),
                 opts.arguments.clone(),
-                &pty_master,
+                pty_master.as_ref(),
             );
             eprintln!("exec child failed: {}", crate::errors::format_chain(&e));
             process::exit(1);
@@ -92,10 +97,12 @@ fn exec_child(
     process_status: &mut crate::procfs::ProcStatus,
     exe: Option<String>,
     args: Vec<String>,
-    pty_master: &OwnedFd,
+    pty_master: Option<&OwnedFd>,
 ) -> Result<std::convert::Infallible, ExecError> {
-    // Attach PTY slave
-    pty::attach_pts(pty_master)?;
+    // Attach PTY slave if one was allocated
+    if let Some(pty_master) = pty_master {
+        pty::attach_pts(pty_master)?;
+    }
 
     // Default to /bin/sh if no command specified
     let exe = exe.or(Some(String::from("/bin/sh")));

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -276,6 +276,17 @@ pub(crate) fn forward_pty_and_wait<T: AsFd>(
     // This will block until child exits or PTY closes
     let _ = forward(pty);
 
+    wait_for_child(child_pid)
+}
+
+/// Whether both stdin and stdout are terminals; if not, we skip PTY allocation
+/// so that redirected/piped output is passed through unmodified.
+pub(crate) fn stdio_is_tty() -> bool {
+    isatty(stdin()) && isatty(stdout())
+}
+
+/// Wait for child process to exit, propagating exit status and job control.
+pub(crate) fn wait_for_child(child_pid: Pid) -> Result<std::convert::Infallible, PtyError> {
     // Wait for child to exit and propagate exit status
     // Loop to handle job control signals (SIGSTOP, SIGCONT) and EINTR
     loop {

--- a/vm-test.nix
+++ b/vm-test.nix
@@ -53,6 +53,11 @@ in
       server.succeed("date +%Z | grep -q UTC")
       server.succeed("cntr attach busybox -- date +%Z | grep -qE 'CET|CEST'")
       server.succeed("cntr exec busybox -- date +%Z | grep -qE 'CET|CEST'")
+      # No PTY when stdio is not a terminal, so binary output is not mangled (issue #181)
+      server.fail("cntr attach busybox -- test -t 1 </dev/null >/dev/null")
+      server.fail("cntr exec busybox -- test -t 1 </dev/null >/dev/null")
+      server.succeed("test \"$(cntr attach busybox -- printf 'a\\nb' </dev/null | wc -c)\" = 3")
+      server.succeed("test \"$(cntr exec busybox -- printf 'a\\nb' </dev/null | wc -c)\" = 3")
     '';
   };
   podman = testers.nixosTest {


### PR DESCRIPTION

Piping or redirecting cntr's output previously went through a forced
PTY, which mangled binary data (\n -> \r\n) and made programs like
zip refuse to write to stdout. Only allocate a PTY when both stdin and
stdout are terminals; otherwise the command inherits cntr's stdio.

Extend the docker NixOS test to verify stdout is not a tty when
redirected and that binary output passes through unmodified.

Fixes #181
